### PR TITLE
Change generated source hint names to have a .g.cs suffix

### DIFF
--- a/Wivuu.JsonPolymorphism/JsonConverterGenerator.cs
+++ b/Wivuu.JsonPolymorphism/JsonConverterGenerator.cs
@@ -74,7 +74,7 @@ namespace Wivuu.JsonPolymorphism
         public void Execute(GeneratorExecutionContext context)
         {
             var jsonAttributeSource = SourceText.From(GeneratorAttributesText, Encoding.UTF8);
-            context.AddSource("JsonDiscriminatorAttributes.cs", jsonAttributeSource);
+            context.AddSource("JsonDiscriminatorAttributes.g.cs", jsonAttributeSource);
 
             // Retreive the populated receiver 
             if (context.SyntaxReceiver is not JsonDiscriminatorReceiver receiver ||
@@ -282,7 +282,7 @@ namespace Wivuu.JsonPolymorphism
                 }
 
                 // Add source
-                context.AddSource($"{parentSymbol.Name}Converter.cs", SourceText.From(sb.ToString(), Encoding.UTF8));
+                context.AddSource($"{parentSymbol.Name}Converter.g.cs", SourceText.From(sb.ToString(), Encoding.UTF8));
             }
         }
 


### PR DESCRIPTION
There is a convention that Coverlet depends upon to detect and ignore 3rd-party assemblies.

This issue explains the problem: https://github.com/coverlet-coverage/coverlet/issues/1164

Without the `.g.cs` suffix it is not possible to generate code coverage in projects that use this package. See https://github.com/dotnet/runtime/pull/53275/commits/f368fcf89b8ec0706dd35d5224c23eb82b46d61b for an example of a fix for the same issue in the dotnet runtime.