### PR TITLE
Generated Converter as Public

### DIFF
--- a/Wivuu.JsonPolymorphism/JsonConverterGenerator.cs
+++ b/Wivuu.JsonPolymorphism/JsonConverterGenerator.cs
@@ -243,7 +243,7 @@ namespace Wivuu.JsonPolymorphism
                     }
 
                     // Converter class
-                    using (sb.AppendLine($"internal class {parentSymbol.Name}Converter : Wivuu.Polymorphism.JsonInheritanceConverter<{parentSymbol.Name}>").Indent('{'))
+                    using (sb.AppendLine($"public class {parentSymbol.Name}Converter : Wivuu.Polymorphism.JsonInheritanceConverter<{parentSymbol.Name}>").Indent('{'))
                     {
                         var renderedName = attr?.ConstructorArguments.Length is > 0 
                             ? attr.ConstructorArguments[0].Value?.ToString() 


### PR DESCRIPTION
Hi again!
I was switching from reflection-based serialization to source-generation-based and noticed an issue.
I have a class with another nested class from another assembly with a discriminator type. The converter for the discriminator is failed to be imported because it's marked as internal. My workaround for now is `InternalsVisibleTo`, but it would be nice to have a better long-term solution!
